### PR TITLE
Password validator may 31

### DIFF
--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/README.md
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/README.md
@@ -1,3 +1,4 @@
+
 # Password validator (#passwordValidator)
 
 > Write a function (or a class) for validating passwords. Passwords must meet the following criteria: 
@@ -7,18 +8,111 @@
 > Contains at least one upper case letter
 > Return an object containing a boolean result and an errors key that — when provided with an invalid password — contains an error message or type for all errors in occurrence. There can be multiple errors at a single time.
 
-## Getting started
+## Upfront Design
+### **Responsibilities**
+### Doings
+- validate password 
+### Knowings
+- it knows a password between 5 and 15 characters log is valid 
+- it knows a password must contain at least one digit (0-9)
+- it knows a password must contain at least one upper case letter (A-Z)
 
-To set up the project, run the following command:
 
-```bash
-npm run install
+### Input
+- a string composed of UTF-8 characters can include letters, numbers and symbols
+
+### Output
+- it returns an object containing: 
+  - a boolean result (true if valid, false if not valid)
+  - errors key
+    - when provided with an invalid password it contains an error message or a type for all error occurrences 
+    - There can be multiple errors in a single line 
+
+
+#### Examples 
+## Valid Password 
+Password length is between range (5-15 characters), it contains at least 1 digit, and it contains at least 1 uppercase letter.
+
+```js
+// input: 15 characters long 
+Passw4rd8H2vB72 
+```
+```js
+// input: 6 characters long
+Passw4
 ```
 
-## To run the tests in development mode
-
-To run the tests and have them reload when you save, run the following command:
-
-```bash
-npm run test:dev
+```js
+// output
+{
+  isValid: true,
+  errors: []
+}
 ```
+
+## Invalid Length
+
+```js
+// input
+Pass4rdisT0000000000000000long
+```
+```js
+// input
+Pa4r
+```
+
+```js
+// output
+{
+  isValid: false,
+  errors: [
+    { type: 'INVALID_LENTH_ERROR' }
+  ]
+}
+```
+
+## Invalid length and no uppercase letters
+```js
+// input 
+asx6
+```
+```js
+// input 
+asx387484945939383779530376
+```
+
+```js
+// output 
+{
+  isValid: false,
+  errors: [
+    { type: 'INVALID_LENGTH_ERROR' },
+    { type: 'NO_UPPERCASE_LETTER_ERROR' },
+  ]
+}
+```
+
+## Invalid length, no uppercase letter, and no digit
+
+```js
+// input
+okkkdjfkalsdlkajlsdkfjlaksdjlfkjl
+```
+```js
+// input
+aaaa
+```
+
+```js
+// output
+{
+  isValid: false,
+  errors: [
+    { type: 'INVALID_LENGTH_ERROR' },
+    { type: 'NO_UPPERCASE_LETTER_ERROR' },
+    { type: 'NO_DIGIT_ERROR' },
+  ]
+}
+```
+
+

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -17,21 +17,25 @@ describe('password validator', () => {
     });
   });
 
-  it('should return true because "Passw4" contains at least one digit', () => {
-    const result = PasswordValidator.validate("Passw4")
-    expect(result.errors).toHaveLength(0);
-    expect(result.isValid).toBeTruthy();
-  }); 
+  describe('checks password contains at least one digit', () => {
+    it.each([
+      { password: "Passw4", isValid: true, errors: [] },
+      { password: "Password", isValid: false, errors: [{ type: "NO_DIGIT_ERROR" }] },
+      { password: "maxwellTheBe", isValid: false, errors: [{ type: 'NO_DIGIT_ERROR'}] },
+    ])
+    ("should return $isValid for '$password'",
+    ({ password, isValid, errors }) => {
+      const result = PasswordValidator.validate(password);
+      expect(result.isValid).toBe(isValid);
+      expect(result.errors).toStrictEqual(errors);
+    });
+  });
 
-  it('should return false because "Password" does not contain at least one digit', () => {
-    const result = PasswordValidator.validate("Password")
-    expect(result.isValid).toBeFalsy();
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors).toStrictEqual([{ type: "NO_DIGIT_ERROR" }])
-  }); 
-
-  it('should return false because "maxwellTheBe" does not contain at least one digit', () => {
-    
-  })
-
+  describe('checks password contains at least one uppercase letter', () => {
+    it('should return false for "as39530376"', () => {
+      const result = PasswordValidator.validate("as39530376");
+      expect(result.isValid).toBeFalsy();
+      expect(result.errors).toStrictEqual([{ type: 'NO_UPPERCASE_LETTER_ERROR' }]);
+    });
+  });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -1,26 +1,45 @@
 import { PasswordValidator } from './index';
 
 describe('password validator', () => {
-  it('knows that "Passw4rd8H2vB72" is between 5 and 15 characters long', () => {
-    // arrange and act
-    const result = PasswordValidator.validate("Passw4rd8H2vB72")
 
-    // assert
-    expect(result.errors).toHaveLength(0);
-    expect(result.isValid).toBeTruthy();
-  });
+  describe('password length is between 5 and 15 characters long', () => {
+    it.each([
+      { password: "Passw4rd8H2vB72", isValid: true, errors: [] },
+      { password: "Passw4", isValid: true, errors: [] },
+      { password: "asX6", isValid: false, errors: [{ type: 'INVALID_LENGTH_ERROR'}] },
+      { password: "asX387484945939383779530376", isValid: false, errors: [{ type: 'INVALID_LENGTH_ERROR'}] },
+    ])
+    ("should return $isValid for '$password'",
+    ({ password, isValid, errors }) => {
+      const result = PasswordValidator.validate(password);
+      expect(result.isValid).toBe(isValid);
+      expect(result.errors).toStrictEqual(errors);
+    });
+  })
 
-  it('knows that "asX6" is NOT between 5 and 15 characters long', () => {
-    const result = PasswordValidator.validate("asX6");
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].type).toMatch(/INVALID_LENGTH_ERROR/);
-    expect(result.isValid).toBeFalsy(); 
-  });
 
-  it('knows that "asX387484945939383779530376" is NOT between 5 and 15 characters', () => {
-    const result = PasswordValidator.validate("asX387484945939383779530376");
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].type).toMatch(/INVALID_LENGTH_ERROR/);
-    expect(result.isValid).toBeFalsy();
-  });
+
+
+  // it('knows that "Passw4rd8H2vB72" is between 5 and 15 characters long', () => {
+  //   // arrange and act
+  //   const result = PasswordValidator.validate("Passw4rd8H2vB72")
+
+  //   // assert
+  //   expect(result.errors).toHaveLength(0);
+  //   expect(result.isValid).toBeTruthy();
+  // });
+
+  // it('knows that "asX6" is NOT between 5 and 15 characters long', () => {
+  //   const result = PasswordValidator.validate("asX6");
+  //   expect(result.errors).toHaveLength(1);
+  //   expect(result.errors[0].type).toMatch(/INVALID_LENGTH_ERROR/);
+  //   expect(result.isValid).toBeFalsy(); 
+  // });
+
+  // it('knows that "asX387484945939383779530376" is NOT between 5 and 15 characters', () => {
+  //   const result = PasswordValidator.validate("asX387484945939383779530376");
+  //   expect(result.errors).toHaveLength(1);
+  //   expect(result.errors[0].type).toMatch(/INVALID_LENGTH_ERROR/);
+  //   expect(result.isValid).toBeFalsy();
+  // });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -30,4 +30,8 @@ describe('password validator', () => {
     expect(result.errors).toStrictEqual([{ type: "NO_DIGIT_ERROR" }])
   }); 
 
+  it('should return false because "maxwellTheBe" does not contain at least one digit', () => {
+    
+  })
+
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -15,31 +15,8 @@ describe('password validator', () => {
       expect(result.isValid).toBe(isValid);
       expect(result.errors).toStrictEqual(errors);
     });
-  })
+  });
 
 
 
-
-  // it('knows that "Passw4rd8H2vB72" is between 5 and 15 characters long', () => {
-  //   // arrange and act
-  //   const result = PasswordValidator.validate("Passw4rd8H2vB72")
-
-  //   // assert
-  //   expect(result.errors).toHaveLength(0);
-  //   expect(result.isValid).toBeTruthy();
-  // });
-
-  // it('knows that "asX6" is NOT between 5 and 15 characters long', () => {
-  //   const result = PasswordValidator.validate("asX6");
-  //   expect(result.errors).toHaveLength(1);
-  //   expect(result.errors[0].type).toMatch(/INVALID_LENGTH_ERROR/);
-  //   expect(result.isValid).toBeFalsy(); 
-  // });
-
-  // it('knows that "asX387484945939383779530376" is NOT between 5 and 15 characters', () => {
-  //   const result = PasswordValidator.validate("asX387484945939383779530376");
-  //   expect(result.errors).toHaveLength(1);
-  //   expect(result.errors[0].type).toMatch(/INVALID_LENGTH_ERROR/);
-  //   expect(result.isValid).toBeFalsy();
-  // });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -37,5 +37,13 @@ describe('password validator', () => {
       expect(result.isValid).toBeFalsy();
       expect(result.errors).toStrictEqual([{ type: 'NO_UPPERCASE_LETTER_ERROR' }]);
     });
+
+    it('should return true for "Passw0rd"', () => {
+      const result = PasswordValidator.validate("Passw0rd");
+      expect(result.isValid).toBeTruthy();
+      expect(result.errors).toStrictEqual([]);
+    });
+
+
   });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -43,7 +43,31 @@ describe('password validator', () => {
       expect(result.isValid).toBeTruthy();
       expect(result.errors).toStrictEqual([]);
     });
-
-
   });
+
+  describe('detects multiple errors', () => {
+    it('should detect that "password" does not contain an uppercase letter and at least 1 digit', () => {
+      const result = PasswordValidator.validate("password");
+      expect(result.isValid).toBeFalsy();
+      expect(result.errors).toStrictEqual(
+        [
+          { type: 'NO_DIGIT_ERROR' },
+          { type: 'NO_UPPERCASE_LETTER_ERROR' },
+        ]
+      );
+    });
+
+    it('should detect that "pass" does not contain an uppercase letter and at least 1 digit, and a valid length', () => {
+      const result = PasswordValidator.validate("pass");
+      expect(result.isValid).toBeFalsy();
+      expect(result.errors).toStrictEqual(
+        [
+          { type: 'INVALID_LENGTH_ERROR' },
+          { type: 'NO_DIGIT_ERROR' },
+          { type: 'NO_UPPERCASE_LETTER_ERROR' },
+        ]
+      );
+    });
+  })
+
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -1,5 +1,12 @@
+import { PasswordValidator } from './index';
 
 describe('password validator', () => {
+  it('knows that "Passw4rd8H2vB72" is between 5 and 15 characters long', () => {
+    // arrange and act
+    const result = PasswordValidator.validate("Passw4rd8H2vB72")
 
+    // assert
+    expect(result.errors).toHaveLength(0);
+    expect(result.isValid).toBeTruthy();
+  });
 })
-

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -17,6 +17,17 @@ describe('password validator', () => {
     });
   });
 
+  it('should return true because "Passw4" contains at least one digit', () => {
+    const result = PasswordValidator.validate("Passw4")
+    expect(result.errors).toHaveLength(0);
+    expect(result.isValid).toBeTruthy();
+  }); 
 
+  it('should return false because "Password" does not contain at least one digit', () => {
+    const result = PasswordValidator.validate("Password")
+    expect(result.isValid).toBeFalsy();
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors).toStrictEqual([{ type: "NO_DIGIT_ERROR" }])
+  }); 
 
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -9,4 +9,11 @@ describe('password validator', () => {
     expect(result.errors).toHaveLength(0);
     expect(result.isValid).toBeTruthy();
   });
+
+  it('knows that "asX6" is NOT between 5 and 15 characters long', () => {
+    const result = PasswordValidator.validate("asX6");
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].type).toMatch(/INVALID_LENGTH_ERROR/);
+    expect(result.isValid).toBeFalsy(); 
+  })
 })

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -15,5 +15,12 @@ describe('password validator', () => {
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].type).toMatch(/INVALID_LENGTH_ERROR/);
     expect(result.isValid).toBeFalsy(); 
-  })
-})
+  });
+
+  it('knows that "asX387484945939383779530376" is NOT between 5 and 15 characters', () => {
+    const result = PasswordValidator.validate("asX387484945939383779530376");
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].type).toMatch(/INVALID_LENGTH_ERROR/);
+    expect(result.isValid).toBeFalsy();
+  });
+});

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
@@ -1,5 +1,8 @@
 export class PasswordValidator {
   static validate(password: string) {
-    
+    return {
+      isValid: true, 
+      errors: []
+    }
   }
 }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
@@ -10,6 +10,10 @@ export class PasswordValidator {
       errors.push({ type: 'NO_DIGIT_ERROR' })
     }
 
+    if (!(/[A-Z]/g).test(password)) {
+      errors.push({ type: 'NO_UPPERCASE_LETTER_ERROR' });
+    }
+
     return {
       isValid: errors.length === 0,
       errors: errors, 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
@@ -1,0 +1,5 @@
+export class PasswordValidator {
+  static validate(password: string) {
+    
+  }
+}

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
@@ -1,8 +1,14 @@
 export class PasswordValidator {
   static validate(password: string) {
+    let errors = [];
+
+    if (!(password.length >= 5 && password.length <= 15)) {
+      errors.push({ type: 'INVALID_LENGTH_ERROR' });
+    }
+
     return {
-      isValid: true, 
-      errors: []
+      isValid: errors.length === 0,
+      errors: errors, 
     }
   }
 }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
@@ -6,6 +6,10 @@ export class PasswordValidator {
       errors.push({ type: 'INVALID_LENGTH_ERROR' });
     }
 
+    if (!(/[0-9]/g).test(password)) {
+      errors.push({ type: 'NO_DIGIT_ERROR' })
+    }
+
     return {
       isValid: errors.length === 0,
       errors: errors, 


### PR DESCRIPTION
- [X] I have implemented the minimum requirements listed in the project description
- [X]  I have Programmed By Wishful Thinking, designing the response API before it was actually created 
- [X] I have Worked Backwards, starting at the Assert, then going to the Act and the Arrange
- [X] I have tests that validate the following statements 
    - [X] "as39530376" returns a false-y response because of a lack of uppercase characters
    - [X] "Password" returns a false-y response because of a lack of digits
    - [X] "asX387484945939383779530376" returns a false-y response because of exceeding the 15 character length
- [X] Once I have made the aforementioned tests pass, I have refactored my test specifications to use `it.each()` to perform parameterization if there is sufficient duplication.
- [X] There is no duplication in my test code or my production code